### PR TITLE
Align transcript/manual panes with toolbar and sync logs toggle

### DIFF
--- a/src/app/components/BottomToolbar.tsx
+++ b/src/app/components/BottomToolbar.tsx
@@ -20,12 +20,6 @@ interface BottomToolbarProps {
   onCodecChange: (newCodec: string) => void;
 }
 
-const statusLabels: Record<SessionStatus, string> = {
-  CONNECTED: "Connected",
-  CONNECTING: "Connecting…",
-  DISCONNECTED: "Disconnected",
-};
-
 function BottomToolbar({
   sessionStatus,
   onToggleConnection,

--- a/src/app/components/PdfPane.tsx
+++ b/src/app/components/PdfPane.tsx
@@ -21,11 +21,18 @@ export default function PdfPane({
   const src = useMemo(() => {
     const page = Math.max(1, Math.floor(renderedPage || 1));
     const zoom = Math.max(10, Math.floor(zoomPct || 80));
-    return `${url}#page=${page}&zoom=${zoom}%25`;
+    return `${url}#page=${page}&zoom=${zoom}`;
   }, [url, renderedPage, zoomPct]);
 
+  const containerClassName = [
+    "flex flex-col flex-1 min-h-0 h-full rounded-lg-theme border border-border bg-card/95 shadow-soft backdrop-blur-sm",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <div className="flex flex-col min-h-0 h-full rounded-lg-theme border border-border bg-card/95 shadow-soft backdrop-blur-sm">
+    <div className={containerClassName}>
       <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-3 border-b border-border bg-accent-soft/60 rounded-t-lg">
         <span className="text-lg font-semibold text-foreground">{label}</span>
         <span className="text-xs uppercase tracking-widest text-muted-soft">


### PR DESCRIPTION
## Summary
- stretch the transcript and manual panes so they fill the vertical space down to the toolbar
- wire the existing show logs toggle to swap the manual with the log view while keeping the manual as the default state
- correct the PDF iframe zoom parameter and clean up an unused constant

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d339d6ba1c83209892a05c66d6817b