### PR TITLE
Refine manual layout and default logs toggle

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -122,6 +122,11 @@ function App() {
   const [isDraggingSplit, setIsDraggingSplit] = useState<boolean>(false);
   const [isDesktopLayout, setIsDesktopLayout] = useState<boolean>(false);
 
+  const handleLogsVisibilityChange = (nextVisible: boolean) => {
+    setIsEventsPaneExpanded(nextVisible);
+    setRightPaneMode(nextVisible ? "logs" : "pdf");
+  };
+
   const goToPage = (page: number) => {
     setPdfPage(Math.max(1, Math.floor(page)));
   };
@@ -133,7 +138,7 @@ function App() {
     const mapped = Math.max(1, Math.floor(printedPage) + pageOffset);
     setPdfPage(mapped);
     // ensure the pane is visible when we jump via citation
-    setRightPaneMode("pdf");
+    handleLogsVisibilityChange(false);
   };
   const getOffset = () => pageOffset;
   const setOffset = (o: number) => setPageOffset(Math.floor(o));
@@ -433,9 +438,6 @@ function App() {
   useEffect(() => {
     const storedPushToTalkUI = localStorage.getItem("pushToTalkUI");
     if (storedPushToTalkUI) setIsPTTActive(storedPushToTalkUI === "true");
-    const storedLogsExpanded = localStorage.getItem("logsExpanded");
-    if (storedLogsExpanded)
-      setIsEventsPaneExpanded(storedLogsExpanded === "true");
     const storedAudioPlaybackEnabled = localStorage.getItem(
       "audioPlaybackEnabled"
     );
@@ -445,9 +447,6 @@ function App() {
   useEffect(() => {
     localStorage.setItem("pushToTalkUI", isPTTActive.toString());
   }, [isPTTActive]);
-  useEffect(() => {
-    localStorage.setItem("logsExpanded", isEventsPaneExpanded.toString());
-  }, [isEventsPaneExpanded]);
   useEffect(() => {
     localStorage.setItem(
       "audioPlaybackEnabled",
@@ -514,7 +513,7 @@ function App() {
       setOffset={setOffset}
     >
       {/* ✅ Height/scroll fixes: allow mobile scroll, keep desktop tidy */}
-      <div className="text-base flex flex-col min-h-screen w-full max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-10 py-5 gap-5 text-foreground overflow-y-auto lg:overflow-hidden relative">
+      <div className="text-base flex flex-col min-h-screen lg:h-screen w-full max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-10 py-5 gap-5 text-foreground overflow-y-auto lg:overflow-hidden relative">
         {/* ===== Top Bar ===== */}
         <div className="flex-none rounded-lg-theme border border-border bg-card/95 backdrop-blur-sm shadow-soft px-5 py-4 flex flex-wrap items-center justify-between gap-4">
           {/* Left: Logo + Title */}
@@ -611,21 +610,19 @@ function App() {
             ref={splitContainerRef}
             className="flex flex-col gap-4 min-h-0 h-full items-stretch lg:flex-row"
           >
-            {/* LEFT: Transcript — ✅ fills to bottom immediately */}
-<div
-  className="flex flex-col min-h-[320px] flex-1 min-w-0 transition-[flex-basis] duration-200"
-  style={leftPaneStyle}
->
-  <div className="flex-1 min-h-0 overflow-hidden rounded-lg-theme border border-border bg-card/95">
-    <Transcript
-      userText={userText}
-      setUserText={setUserText}
-      onSendMessage={handleSendTextMessage}
-      downloadRecording={downloadRecording}
-      canSend={sessionStatus === "CONNECTED"}
-    />
-  </div>
-</div>
+            {/* LEFT: Transcript — ✅ stretches to the toolbar */}
+            <div
+              className="flex flex-col min-h-[320px] lg:min-h-0 flex-1 min-w-0 h-full transition-[flex-basis] duration-200"
+              style={leftPaneStyle}
+            >
+              <Transcript
+                userText={userText}
+                setUserText={setUserText}
+                onSendMessage={handleSendTextMessage}
+                downloadRecording={downloadRecording}
+                canSend={sessionStatus === "CONNECTED"}
+              />
+            </div>
 
             {/* Divider (desktop) */}
             <div
@@ -656,29 +653,22 @@ function App() {
               </button>
             </div>
 
-            {/* RIGHT: PDF / Logs — ✅ PDF fills box on phone & desktop */}
-<div
-  className="flex flex-col min-h-[320px] flex-1 min-w-0 transition-[flex-basis] duration-200"
-  style={rightPaneStyle}
->
-  <div className="flex-1 min-h-0 overflow-hidden rounded-lg-theme border border-border bg-card/95">
-    {rightPaneMode === "pdf" ? (
-      // Phone: tall viewport; Desktop: stretch to bottom.
-      <div className="relative h-[65vh] sm:h-[70vh] lg:h-full w-full">
-        <PdfPane
-          url={MARY_PDF_URL}
-          renderedPage={pdfPage}
-          zoomPct={pdfZoom}
-          label="PSW Manual"
-        />
-      </div>
-    ) : (
-      <div className="h-full w-full overflow-auto">
-        <Events isExpanded={isEventsPaneExpanded} />
-      </div>
-    )}
-  </div>
-</div>
+            {/* RIGHT: PDF / Logs — ✅ matches transcript height */}
+            <div
+              className="flex flex-col min-h-[320px] lg:min-h-0 flex-1 min-w-0 h-full transition-[flex-basis] duration-200"
+              style={rightPaneStyle}
+            >
+              {rightPaneMode === "pdf" ? (
+                <PdfPane
+                  url={MARY_PDF_URL}
+                  renderedPage={pdfPage}
+                  zoomPct={pdfZoom}
+                  label="PSW Manual"
+                />
+              ) : (
+                <Events isExpanded={isEventsPaneExpanded} />
+              )}
+            </div>
 
           </div>
         </div>
@@ -693,7 +683,7 @@ function App() {
           handleTalkButtonDown={handleTalkButtonDown}
           handleTalkButtonUp={handleTalkButtonUp}
           isEventsPaneExpanded={isEventsPaneExpanded}
-          setIsEventsPaneExpanded={setIsEventsPaneExpanded}
+          setIsEventsPaneExpanded={handleLogsVisibilityChange}
           isAudioPlaybackEnabled={isAudioPlaybackEnabled}
           setIsAudioPlaybackEnabled={setIsAudioPlaybackEnabled}
           codec={urlCodec}

--- a/src/app/components/BottomToolbar.tsx
+++ b/src/app/components/BottomToolbar.tsx
@@ -20,12 +20,6 @@ interface BottomToolbarProps {
   onCodecChange: (newCodec: string) => void;
 }
 
-const statusLabels: Record<SessionStatus, string> = {
-  CONNECTED: "Connected",
-  CONNECTING: "Connecting…",
-  DISCONNECTED: "Disconnected",
-};
-
 function BottomToolbar({
   sessionStatus,
   onToggleConnection,

--- a/src/app/components/PdfPane.tsx
+++ b/src/app/components/PdfPane.tsx
@@ -6,7 +6,7 @@ import React, { useMemo } from "react";
 export type PdfPaneProps = {
   url: string;
   renderedPage: number;
-  zoomPct: number;
+  zoomPct?: number;
   label?: string;
   className?: string;
 };
@@ -18,19 +18,36 @@ export default function PdfPane({
   label = "Manual",
   className,
 }: PdfPaneProps) {
+  const normalizedZoom = useMemo(
+    () => Math.max(10, Math.floor(zoomPct ?? 80)),
+    [zoomPct]
+  );
+
   const src = useMemo(() => {
     const page = Math.max(1, Math.floor(renderedPage || 1));
-    const zoom = Math.max(10, Math.floor(zoomPct || 80));
-    return `${url}#page=${page}&zoom=${zoom}%25`;
-  }, [url, renderedPage, zoomPct]);
+    const zoomParam = normalizedZoom <= 100 ? "page-fit" : String(normalizedZoom);
+    return `${url}#page=${page}&zoom=${zoomParam}`;
+  }, [url, renderedPage, normalizedZoom]);
+
+  const containerClassName = [
+    "flex flex-col flex-1 min-h-0 h-full rounded-lg-theme border border-border bg-card/95 shadow-soft backdrop-blur-sm",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
-    <div className="flex flex-col min-h-0 h-full rounded-lg-theme border border-border bg-card/95 shadow-soft backdrop-blur-sm">
+    <div className={containerClassName}>
       <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-3 border-b border-border bg-accent-soft/60 rounded-t-lg">
         <span className="text-lg font-semibold text-foreground">{label}</span>
-        <span className="text-xs uppercase tracking-widest text-muted-soft">
-          Page {renderedPage} | {zoomPct}%
-        </span>
+        <a
+          href={url}
+          target="_blank"
+          rel="noreferrer"
+          className="text-xs font-medium uppercase tracking-widest text-accent hover:text-accent/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 rounded-full px-3 py-1"
+        >
+          Open manual
+        </a>
       </div>
       <div className="flex-1 min-h-[280px] relative">
         <iframe


### PR DESCRIPTION
## Summary
- clamp the main dashboard container to the viewport and let both content columns flex down to the toolbar without adding body scroll
- stop persisting the logs toggle so the manual reliably loads by default while the toggle still swaps panes when used
- update the PDF pane to use page-fit scaling and replace the nonfunctional page/zoom label with an "Open manual" shortcut

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d339d6ba1c83209892a05c66d6817b