### PR TITLE
Add microphone diagnostics and warnings V2

### DIFF
--- a/src/app/components/BottomToolbar.tsx
+++ b/src/app/components/BottomToolbar.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
-import { SessionStatus } from "@/app/types";
+import { MicrophoneDiagnostics, SessionStatus } from "@/app/types";
 import {
   Plug,
   PlugZap,
@@ -10,6 +10,7 @@ import {
   Mic,
   MicOff,
   Volume2,
+  AlertTriangle,
   ListTree, // note: capital T
 } from "lucide-react";
 
@@ -32,6 +33,8 @@ interface BottomToolbarProps {
   /** Preserved for compatibility; not rendered in UI */
   codec?: string;
   onCodecChange?: (newCodec: string) => void;
+
+  microphoneDiagnostics?: MicrophoneDiagnostics;
 }
 
 function BottomToolbar({
@@ -49,6 +52,7 @@ function BottomToolbar({
 
   isAudioPlaybackEnabled,
   setIsAudioPlaybackEnabled,
+  microphoneDiagnostics,
 }: BottomToolbarProps) {
   const isConnected = sessionStatus === "CONNECTED";
   const isConnecting = sessionStatus === "CONNECTING";
@@ -82,12 +86,22 @@ function BottomToolbar({
   // Safe talk wrappers: no-op unless connected & PTT enabled
   const canTalk = mounted && isConnected && isPTTActive;
 
-  const onSafeTalkDown = (e: React.MouseEvent | React.TouchEvent) => {
+  const micLevelPercent = Math.min(
+    100,
+    Math.max(0, Math.round((microphoneDiagnostics?.level ?? 0) * 100)),
+  );
+  const micLabel = microphoneDiagnostics?.activeMicrophoneLabel
+    ? microphoneDiagnostics.activeMicrophoneLabel
+    : isConnected
+    ? "Microphone ready"
+    : "Microphone idle";
+
+  const onSafeTalkDown = () => {
     if (!canTalk) return;
     handleTalkButtonDown();
   };
 
-  const onSafeTalkUp = (e: React.MouseEvent | React.TouchEvent) => {
+  const onSafeTalkUp = () => {
     if (!canTalk) return;
     handleTalkButtonUp();
   };
@@ -109,75 +123,109 @@ function BottomToolbar({
         </button>
 
         {/* Push-to-Talk */}
-        <div className="flex flex-wrap items-center gap-3">
-          <span className="font-medium text-muted-soft inline-flex items-center gap-2">
-            <Mic className="h-4 w-4 opacity-80" />
-            Push to talk
-          </span>
+        <div className="flex flex-col gap-2 min-w-[260px]">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="font-medium text-muted-soft inline-flex items-center gap-2">
+              <Mic className="h-4 w-4 opacity-80" />
+              Push to talk
+            </span>
 
-          {/* PTT Toggle chip */}
-          <button
-            type="button"
-            onClick={() => setIsPTTActive(!isPTTActive)}
-            disabled={!isConnected}
-            aria-pressed={mounted ? isPTTActive : undefined}
-            className={[
-              "inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 bg-card/80 transition-all",
-              !isConnected ? "opacity-50 cursor-not-allowed" : "hover:bg-card",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
-            ].join(" ")}
-          >
-            <span
+            {/* PTT Toggle chip */}
+            <button
+              type="button"
+              onClick={() => setIsPTTActive(!isPTTActive)}
+              disabled={!isConnected}
+              aria-pressed={mounted ? isPTTActive : undefined}
               className={[
-                "h-2.5 w-2.5 rounded-full",
-                mounted
-                  ? isPTTActive
-                    ? "bg-[var(--accent)]"
-                    : "bg-muted"
-                  : "bg-muted",
+                "inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 bg-card/80 transition-all",
+                !isConnected ? "opacity-50 cursor-not-allowed" : "hover:bg-card",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
               ].join(" ")}
-              aria-hidden
-              suppressHydrationWarning
-            />
-            <span className="text-sm" suppressHydrationWarning>
-              {mounted ? (isPTTActive ? "Enabled" : "Disabled") : "—"}
-            </span>
-          </button>
+            >
+              <span
+                className={[
+                  "h-2.5 w-2.5 rounded-full",
+                  mounted
+                    ? isPTTActive
+                      ? "bg-[var(--accent)]"
+                      : "bg-muted"
+                    : "bg-muted",
+                ].join(" ")}
+                aria-hidden
+                suppressHydrationWarning
+              />
+              <span className="text-sm" suppressHydrationWarning>
+                {mounted ? (isPTTActive ? "Enabled" : "Disabled") : "—"}
+              </span>
+            </button>
 
-          {/* Talk button — modern, clear, hold-to-talk */}
-          <button
-            onMouseDown={onSafeTalkDown}
-            onMouseUp={onSafeTalkUp}
-            onTouchStart={onSafeTalkDown}
-            onTouchEnd={onSafeTalkUp}
-            disabled={!canTalk}
-            aria-pressed={mounted ? isPTTUserSpeaking : undefined}
-            title={
-              isConnected
-                ? isPTTActive
-                  ? "Hold to talk"
-                  : "Enable Push to talk to use"
-                : "Connect first"
-            }
-            className={[
-              "relative inline-flex items-center justify-center gap-2 px-5 py-2 rounded-full transition-all border border-transparent",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
-              canTalk
-                ? isPTTUserSpeaking
-                  ? "bg-emerald-600 text-white shadow-sm scale-[0.99]"
-                  : "bg-accent-soft text-accent hover:bg-accent-soft/80 hover:shadow-sm"
-                : "bg-accent-soft/60 text-accent/70 cursor-not-allowed opacity-50",
-            ].join(" ")}
-          >
-            {isPTTUserSpeaking ? <Mic className="h-4 w-4" /> : <MicOff className="h-4 w-4" />}
-            <span className="font-medium" suppressHydrationWarning>
-              {mounted ? (canTalk ? (isPTTUserSpeaking ? "Listening… (Hold)" : "Hold to Talk") : "Talk") : "Talk"}
-            </span>
+            {/* Talk button — modern, clear, hold-to-talk */}
+            <button
+              onMouseDown={onSafeTalkDown}
+              onMouseUp={onSafeTalkUp}
+              onTouchStart={onSafeTalkDown}
+              onTouchEnd={onSafeTalkUp}
+              disabled={!canTalk}
+              aria-pressed={mounted ? isPTTUserSpeaking : undefined}
+              title={
+                isConnected
+                  ? isPTTActive
+                    ? "Hold to talk"
+                    : "Enable Push to talk to use"
+                  : "Connect first"
+              }
+              className={[
+                "relative inline-flex items-center justify-center gap-2 px-5 py-2 rounded-full transition-all border border-transparent",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
+                canTalk
+                  ? isPTTUserSpeaking
+                    ? "bg-emerald-600 text-white shadow-sm scale-[0.99]"
+                    : "bg-accent-soft text-accent hover:bg-accent-soft/80 hover:shadow-sm"
+                  : "bg-accent-soft/60 text-accent/70 cursor-not-allowed opacity-50",
+              ].join(" ")}
+            >
+              {isPTTUserSpeaking ? <Mic className="h-4 w-4" /> : <MicOff className="h-4 w-4" />}
+              <span className="font-medium" suppressHydrationWarning>
+                {mounted
+                  ? canTalk
+                    ? isPTTUserSpeaking
+                      ? "Listening… (Hold)"
+                      : "Hold to Talk"
+                    : "Talk"
+                  : "Talk"}
+              </span>
 
-            {mounted && isPTTUserSpeaking && (
-              <span className="absolute inset-0 rounded-full ring-2 ring-emerald-600/30 animate-ping pointer-events-none" />
-            )}
-          </button>
+              {mounted && isPTTUserSpeaking && (
+                <span className="absolute inset-0 rounded-full ring-2 ring-emerald-600/30 animate-ping pointer-events-none" />
+              )}
+            </button>
+          </div>
+
+          <div className="min-h-[18px]">
+            {microphoneDiagnostics ? (
+              microphoneDiagnostics.alert ? (
+                <div
+                  className="inline-flex items-center gap-1 text-xs font-medium text-red-500"
+                  role="status"
+                >
+                  <AlertTriangle className="h-3.5 w-3.5" />
+                  <span>{microphoneDiagnostics.alert}</span>
+                </div>
+              ) : (
+                <div className="flex items-center gap-2 text-xs text-muted-soft">
+                  <span className="truncate max-w-[160px]">
+                    {micLabel}
+                  </span>
+                  <div className="relative h-1.5 w-24 overflow-hidden rounded-full bg-muted/30">
+                    <span
+                      className="absolute inset-y-0 left-0 rounded-full bg-emerald-500 transition-all duration-200"
+                      style={{ width: `${micLevelPercent}%` }}
+                    />
+                  </div>
+                </div>
+              )
+            ) : null}
+          </div>
         </div>
 
         {/* Audio Playback */}

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -16,6 +16,32 @@ export const ModerationCategoryZod = z.enum([...MODERATION_CATEGORIES]);
 
 export type SessionStatus = "DISCONNECTED" | "CONNECTING" | "CONNECTED";
 
+export type BrowserPermissionState = PermissionState | "unsupported" | "unknown";
+
+export type MicrophoneTrackState =
+  | "unavailable"
+  | "ok"
+  | "muted"
+  | "disabled"
+  | "ended";
+
+export interface MicrophoneDiagnostics {
+  /** Normalized level in the range [0, 1] derived from WebRTC stats (best effort). */
+  level: number;
+  /** Friendly message explaining the most actionable microphone issue (if any). */
+  alert: string | null;
+  /** Resolved browser permission state for the microphone. */
+  permission: BrowserPermissionState;
+  /** Whether at least one microphone device is currently available. */
+  hasDevice: boolean;
+  /** State derived from the local audio track backing the realtime session. */
+  trackState: MicrophoneTrackState;
+  /** Whether a prolonged period of silence was detected while the user was speaking. */
+  noInputDetected: boolean;
+  /** Friendly label for the active microphone device (if available). */
+  activeMicrophoneLabel: string | null;
+}
+
 export interface ToolParameterProperty {
   type: string;
   description?: string;


### PR DESCRIPTION
## Summary
- monitor browser microphone permissions, device availability, and realtime audio stats to detect silent or muted input
- surface microphone diagnostics in the push-to-talk toolbar so users see actionable warnings before assuming a backend issue
- expose realtime connection helpers so diagnostics can inspect the local WebRTC track without altering session behaviour

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d45b794a9c8320a33164dfe1c5f6b2